### PR TITLE
Canonicalize CRAN links

### DIFF
--- a/part2/Part2.Rmd
+++ b/part2/Part2.Rmd
@@ -163,7 +163,7 @@ Finally, the sequences are ready for phylogenetic inference.
 
 - For this, we used [`FastTree`](http://www.microbesonline.org/fasttree/).  As its name implies, it is fast and capable of handling large datasets requiring minimal resources.
 - The resulting tree is rendered using the [`ETE3`](http://etetoolkit.org/) python API.
-- R is used to calculate a distance matrix from the multiple sequence alignment using the [ape](https://cran.r-project.org/web/packages/ape/index.html) library and [`plotly`](https://plot.ly/r/) for visualization.  
+- R is used to calculate a distance matrix from the multiple sequence alignment using the [ape](https://cran.r-project.org/package=ape) library and [`plotly`](https://plot.ly/r/) for visualization.  
 
 In part 3 of this series we will talk more about the distance matrix calculation and how logistic regression was used to look at inter- and intra patient genetic distances of HIV sequences by mining a large public database.  This was important, the insights gained here were used to colour the distance matrix so that the user's attention is drawn to relevant samples.  
 

--- a/part2/Part2.html
+++ b/part2/Part2.html
@@ -490,7 +490,7 @@ The chemical structures of 3TC (left) and FTC (right). Available at <a href="htt
 <ul>
 <li>For this, we used <a href="http://www.microbesonline.org/fasttree/"><code>FastTree</code></a>. As its name implies, it is fast and capable of handling large datasets requiring minimal resources.</li>
 <li>The resulting tree is rendered using the <a href="http://etetoolkit.org/"><code>ETE3</code></a> python API.</li>
-<li>R is used to calculate a distance matrix from the multiple sequence alignment using the <a href="https://cran.r-project.org/web/packages/ape/index.html">ape</a> library and <a href="https://plot.ly/r/"><code>plotly</code></a> for visualization.</li>
+<li>R is used to calculate a distance matrix from the multiple sequence alignment using the <a href="https://cran.r-project.org/package=ape">ape</a> library and <a href="https://plot.ly/r/"><code>plotly</code></a> for visualization.</li>
 </ul>
 <p>In part 3 of this series we will talk more about the distance matrix calculation and how logistic regression was used to look at inter- and intra patient genetic distances of HIV sequences by mining a large public database. This was important, the insights gained here were used to colour the distance matrix so that the user’s attention is drawn to relevant samples.</p>
 <p>This is an R for medicine blog post, but there is a lot of jargon in the paragraph above. We can clear things up a bit, but please check out our <a href="https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0213241">publication</a>.</p>


### PR DESCRIPTION
CRAN [asks people](https://cran.r-project.org/doc/manuals/R-exts.html#Specifying-URLs) to use this URL variant when linking to packages ;-) This PR results from a semi-automatic search-and-replace script and implements their suggestion.
